### PR TITLE
Add new API endpoints for room entity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,38 @@ target/*
 
 target/
 
+## Spring ignores ###
+
+HELP.md
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,11 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<optional>true</optional>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/example/demo/controller/HotelController.java
+++ b/src/main/java/com/example/demo/controller/HotelController.java
@@ -1,7 +1,7 @@
-package com.example.demo.controllers;
+package com.example.demo.controller;
 
-import com.example.demo.HotelRepository;
-import com.example.demo.models.Hotel;
+import com.example.demo.repository.HotelRepository;
+import com.example.demo.model.Hotel;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -81,6 +81,4 @@ public class HotelController {
 
         return "redirect:/hotels";
     }
-
-
 }

--- a/src/main/java/com/example/demo/controller/MainController.java
+++ b/src/main/java/com/example/demo/controller/MainController.java
@@ -1,4 +1,4 @@
-package com.example.demo.controllers;
+package com.example.demo.controller;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;

--- a/src/main/java/com/example/demo/controller/RoomController.java
+++ b/src/main/java/com/example/demo/controller/RoomController.java
@@ -1,0 +1,45 @@
+package com.example.demo.controller;
+
+import com.example.demo.model.Room;
+import com.example.demo.repository.HotelRepository;
+import com.example.demo.model.Hotel;
+import com.example.demo.repository.RoomRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.*;
+
+@RestController
+public class RoomController {
+
+    @Autowired
+    private RoomRepository roomRepository;
+
+    @Autowired
+    private HotelRepository hotelRepository;
+
+    @PostMapping("/rooms/add")
+    public Room roomsPostAdd(@RequestParam Integer number, @RequestParam Long hotelId) {
+        Hotel hotel = hotelRepository.findById(hotelId).orElseThrow();
+        Room room = new Room(number, hotel);
+        return roomRepository.save(room);
+    }
+
+    @GetMapping("/rooms")
+    public List<Room> findAllRooms() {
+        return (List<Room>) roomRepository.findAll();
+    }
+
+    @GetMapping("/rooms/allHotelRooms")
+    public Set<Room> findAllHotelRooms(@RequestParam Long hotelId) {
+        Hotel hotel = hotelRepository.findById(hotelId).orElseThrow();
+        return hotel.getRooms();
+    }
+
+    @PostMapping("/rooms/occupy")
+    public Room occupyRoom(@RequestParam Long roomId) {
+        Room room = roomRepository.findById(roomId).orElseThrow();
+        room.setOccupied(true);
+        return roomRepository.save(room);
+    }
+}

--- a/src/main/java/com/example/demo/model/Hotel.java
+++ b/src/main/java/com/example/demo/model/Hotel.java
@@ -1,9 +1,8 @@
-package com.example.demo.models;
+package com.example.demo.model;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import javax.persistence.*;
+import java.util.HashSet;
+import java.util.Set;
 
 @Entity
 public class Hotel {
@@ -11,6 +10,9 @@ public class Hotel {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
+
+    @OneToMany(mappedBy = "hotel", cascade = CascadeType.ALL)
+    private Set<Room> rooms = new HashSet<>();
 
     private String name;
     private String address;
@@ -57,5 +59,9 @@ public class Hotel {
 
     public void setPhone(String phone) {
         this.phone = phone;
+    }
+
+    public Set<Room> getRooms() {
+        return rooms;
     }
 }

--- a/src/main/java/com/example/demo/model/Room.java
+++ b/src/main/java/com/example/demo/model/Room.java
@@ -1,0 +1,61 @@
+package com.example.demo.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+import javax.persistence.*;
+
+@AllArgsConstructor
+@Builder
+@Getter
+@Setter
+@Entity
+public class Room {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "occupied", nullable = false)
+    private boolean occupied;
+
+    @Column(name = "number", nullable = false)
+    private Integer number;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "hotel_id")
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    private Hotel hotel;
+
+    public Room() {
+    }
+
+    public Room(Integer number, Hotel hotel) {
+        this.occupied = false;
+        this.number = number;
+        this.hotel = hotel;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Boolean getOccupied() {
+        return occupied;
+    }
+
+    public void setOccupied(Boolean occupied) {
+        this.occupied = occupied;
+    }
+
+    public Integer getNumber() {
+        return number;
+    }
+
+    public void setNumber(Integer number) {
+        this.number = number;
+    }
+}

--- a/src/main/java/com/example/demo/repository/HotelRepository.java
+++ b/src/main/java/com/example/demo/repository/HotelRepository.java
@@ -1,6 +1,6 @@
-package com.example.demo;
+package com.example.demo.repository;
 
-import com.example.demo.models.Hotel;
+import com.example.demo.model.Hotel;
 import org.springframework.data.repository.CrudRepository;
 
 public interface HotelRepository extends CrudRepository<Hotel, Long> {

--- a/src/main/java/com/example/demo/repository/RoomRepository.java
+++ b/src/main/java/com/example/demo/repository/RoomRepository.java
@@ -1,0 +1,8 @@
+package com.example.demo.repository;
+
+import com.example.demo.model.Room;
+import org.springframework.data.repository.CrudRepository;
+
+public interface RoomRepository extends CrudRepository<Room, Long> {
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,9 @@
-spring.jpa.hibernate.ddl-auto=update
-spring.datasource.url=jdbc:mysql://${MYSQL_HOST:localhost}:3306/hotelmanagement
-spring.datasource.username=root
-spring.datasource.password=951753qwerty
+spring.datasource.url = jdbc:mysql://localhost:3306/hotelmanagement
+spring.datasource.username = ironsoul
+spring.datasource.password = ironsoul
+
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.jpa.show-sql = true
+spring.jpa.hibernate.ddl-auto = update
+spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.MySQL5Dialect
+


### PR DESCRIPTION
Mock SQL queries for adding rooms and hotels:

```
INSERT INTO hotel (id, name, address, phone, views) VALUES (1, "San Andreas", "LA", "77772932868", 0);
INSERT INTO hotel (id, name, address, phone, views) VALUES (2, "Azimovich", "Sherkhan", "870121232", 5);
INSERT INTO room (id, occupied, number, hotel_id) VALUES (1, 0, 1, 1);
INSERT INTO room (id, occupied, number, hotel_id) VALUES (2, 1, 7, 2);
```

Now you can access these new endpoints

- GET `/rooms` - get info about all rooms in all hotels
- GET `/rooms/allHotelRooms?hotelId=1` - get info about all rooms in hotel with ID 1
- POST `/rooms/occupy?roomId=1` - occupy room with ID 1